### PR TITLE
9 msbuild integration does not work under linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1-alpha1.240607.1]
+
+### Added
+
+- [PR 10] Adds error handling for MSBuild-related runtime errors (#9)
+- [PR 10] Extends the build and SDK services location functionality to properly detect MSBuild dependencies under Linux (#9)
+
+### Fixed
+
+- [PR 10] Fixes MSBuild location under Linux (#9)
+
+
+## [0.3.0-alpha1.240606.1]
 
 ### Added
 
@@ -21,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [PR #8] Fixes broken task factories
+
 
 ## [0.2.0-alpha1.240419.1] - 2024-04-19
 

--- a/src/dotnet.nugit.UnitTest/AddPackagesFromRepositoryCommandTest.cs
+++ b/src/dotnet.nugit.UnitTest/AddPackagesFromRepositoryCommandTest.cs
@@ -39,9 +39,12 @@ namespace dotnet.nugit.UnitTest
                 .Setup(task => task.BuildRepositoryPackagesAsync(It.IsAny<RepositoryReference>(), feed, repositoryMock.Object, null, null, It.IsAny<CancellationToken>()))
                 .Verifiable();
 
+            var msBuildToolsLocatorMock = new Mock<IMsBuildToolsLocator>();
+            
             var sut = new AddPackagesFromRepositoryCommand(
                 feedService.Object,
                 workspace.Object,
+                msBuildToolsLocatorMock.Object,
                 OpenRepositoryTaskFactory,
                 BuildPackagesTaskFactory,
                 new NullLogger<AddPackagesFromRepositoryCommand>());

--- a/src/dotnet.nugit/Commands/AddPackagesFromRepositoryCommand.cs
+++ b/src/dotnet.nugit/Commands/AddPackagesFromRepositoryCommand.cs
@@ -18,6 +18,7 @@ namespace dotnet.nugit.Commands
     public class AddPackagesFromRepositoryCommand(
         INuGetFeedConfigurationService nuGetFeedConfigurationService,
         INugitWorkspace workspace,
+        IMsBuildToolsLocator msBuildToolsLocator,
         Func<IOpenRepositoryTask> openRepositoryTaskFactory,
         Func<IBuildRepositoryPackagesTask> buildPackagesTaskFactory,
         ILogger<AddPackagesFromRepositoryCommand> logger)
@@ -27,11 +28,14 @@ namespace dotnet.nugit.Commands
         private readonly INuGetFeedConfigurationService nuGetFeedConfigurationService = nuGetFeedConfigurationService ?? throw new ArgumentNullException(nameof(nuGetFeedConfigurationService));
         private readonly Func<IOpenRepositoryTask> openRepositoryTaskFactory = openRepositoryTaskFactory ?? throw new ArgumentNullException(nameof(openRepositoryTaskFactory));
         private readonly INugitWorkspace workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        private readonly IMsBuildToolsLocator msBuildToolsLocator = msBuildToolsLocator ?? throw new ArgumentNullException(nameof(msBuildToolsLocator));
 
         public async Task<int> ProcessRepositoryAsync(string repositoryReferenceString, bool headOnly, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(repositoryReferenceString)) throw new ArgumentException(Resources.ArgumentException_Value_cannot_be_null_or_whitespace, nameof(repositoryReferenceString));
 
+            this.msBuildToolsLocator.Initialize();
+            
             LocalFeedInfo? feed = await this.nuGetFeedConfigurationService.GetConfiguredLocalFeedAsync(cancellationToken);
             if (feed == null) return ErrLocalFeedNotFound;
 

--- a/src/dotnet.nugit/Services/Workspace/CustomAssemblyLoadContext.cs
+++ b/src/dotnet.nugit/Services/Workspace/CustomAssemblyLoadContext.cs
@@ -1,0 +1,25 @@
+namespace dotnet.nugit.Services.Workspace
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Runtime.Loader;
+
+    public class CustomAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly Dictionary<AssemblyName, Assembly> assemblies = new();
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            return this.assemblies.GetValueOrDefault(assemblyName)!;
+        }
+
+        public void CacheAssembly(AssemblyName assemblyName, Assembly assembly)
+        {
+            ArgumentNullException.ThrowIfNull(assemblyName);
+            ArgumentNullException.ThrowIfNull(assembly);
+
+            this.assemblies.Add(assemblyName, assembly);
+        }
+    }
+}

--- a/src/dotnet.nugit/Services/Workspace/DotNetProject.cs
+++ b/src/dotnet.nugit/Services/Workspace/DotNetProject.cs
@@ -23,7 +23,6 @@
         {
             ArgumentNullException.ThrowIfNull(fileSystem);
             ArgumentNullException.ThrowIfNull(project);
-            ArgumentNullException.ThrowIfNull(projectInstance);
 
             this.fileSystem = fileSystem;
             this.project = project;

--- a/src/dotnet.nugit/Services/Workspace/MsBuildToolsLocatorService.cs
+++ b/src/dotnet.nugit/Services/Workspace/MsBuildToolsLocatorService.cs
@@ -2,33 +2,92 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO.Abstractions;
+    using System.Reflection;
+    using System.Runtime.Loader;
     using Abstractions;
+    using Microsoft.Extensions.Logging;
 
-    public sealed class MsBuildToolsLocatorService(IEnumerable<IMsBuildToolPathLocator> msBuildLocators) : IMsBuildToolsLocator
+    public sealed class MsBuildToolsLocatorService : IMsBuildToolsLocator, IDisposable
     {
-        private readonly IEnumerable<IMsBuildToolPathLocator> msBuildLocators = msBuildLocators ?? throw new ArgumentNullException(nameof(msBuildLocators));
+        private readonly CustomAssemblyLoadContext assemblyLoadContext;
+        private readonly IFileSystem fileSystem;
+        private readonly ILogger<MsBuildToolsLocatorService> logger;
+        private readonly IEnumerable<IMsBuildToolPathLocator> msBuildLocators;
         private bool initialized;
-        private string? path;
+        private string? msBuildToolsPath;
+
+        public MsBuildToolsLocatorService(
+            IFileSystem fileSystem,
+            IEnumerable<IMsBuildToolPathLocator> msBuildLocators,
+            ILogger<MsBuildToolsLocatorService> logger)
+        {
+            this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+            this.msBuildLocators = msBuildLocators ?? throw new ArgumentNullException(nameof(msBuildLocators));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.assemblyLoadContext = new CustomAssemblyLoadContext();
+        }
+
+        public void Dispose()
+        {
+            AssemblyLoadContext.Default.Resolving -= this.DefaultOnResolving;
+        }
 
         public string? LocateMsBuildToolsPath()
         {
-            if (this.initialized) return this.path;
+            if (this.initialized) return this.msBuildToolsPath;
 
             foreach (IMsBuildToolPathLocator toolPathLocator in this.msBuildLocators)
             {
-                if (!toolPathLocator.TryLocateMsBuildToolsPath(out string? path))
+                if (!toolPathLocator.TryLocateMsBuildToolsPath(out string? resolvedPath))
                     continue;
 
-                this.path = path;
+                this.msBuildToolsPath = resolvedPath;
                 this.initialized = true;
             }
 
-            return this.path;
+            return this.msBuildToolsPath;
         }
 
         public void Initialize()
         {
-            this.LocateMsBuildToolsPath();
+            AssemblyLoadContext.Default.Resolving += this.DefaultOnResolving;
+
+            string? buildToolsPath = this.LocateMsBuildToolsPath();
+            if (buildToolsPath == null) return;
+        }
+
+        private Assembly? DefaultOnResolving(AssemblyLoadContext context, AssemblyName assemblyName)
+        {
+            if (this.initialized == false || string.IsNullOrWhiteSpace(this.msBuildToolsPath)) return null;
+
+            this.logger.LogDebug("Resolution of assembly {AssemblyName} has failed.", assemblyName.Name);
+
+            string executionAssemblyLocation = Assembly.GetExecutingAssembly().Location;
+            string? installationPath = this.fileSystem.Path.GetDirectoryName(executionAssemblyLocation);
+            string?[] paths = { installationPath, this.msBuildToolsPath };
+            foreach (string? p in paths)
+            {
+                Assembly? assembly = this.LoadAssemblyFromPath(p, assemblyName);
+                if (assembly != null) return assembly;
+            }
+
+            return null;
+        }
+
+        private Assembly? LoadAssemblyFromPath(string? path, AssemblyName assemblyName)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return null;
+            string assemblyPath = this.fileSystem.Path.Combine(path, $"{assemblyName.Name}.dll");
+            if (this.fileSystem.File.Exists(assemblyPath))
+            {
+                this.logger.LogInformation("Loading {AssemblyName} from path: {Path}", assemblyName.Name, path);
+                Assembly assembly = this.assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
+                this.assemblyLoadContext.CacheAssembly(assemblyName, assembly);
+                return assembly;
+            }
+
+            return null;
         }
     }
 }

--- a/src/dotnet.nugit/Services/Workspace/ProjectWorkspaceLogger.cs
+++ b/src/dotnet.nugit/Services/Workspace/ProjectWorkspaceLogger.cs
@@ -25,7 +25,7 @@ namespace dotnet.nugit.Services.Workspace
         }
 
         public LoggerVerbosity Verbosity { get; set; }
-        public string Parameters { get; set; } = null!;
+        public string? Parameters { get; set; }
 
         private void HandleAnyEvent(object sender, BuildEventArgs? e)
         {

--- a/src/dotnet.nugit/dotnet.nugit.csproj
+++ b/src/dotnet.nugit/dotnet.nugit.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <FileVersion>0.1.2</FileVersion>
+        <AssemblyName>dotnet-nugit</AssemblyName>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
+        <FileVersion>0.3.0</FileVersion>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <AssemblyName>dotnet-nugit</AssemblyName>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -22,7 +22,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/matzefriedrich/dotnet-nugit</RepositoryUrl>
         <Title>dotnet nugit</Title>
-        <Version>0.2.0-alpha1.240419.1</Version>
+        <Version>0.3.0-alpha1.240606.1</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -46,22 +46,20 @@
 
     <ItemGroup>
         <PackageReference Include="LibGit2Sharp" Version="0.30.0"/>
-        <PackageReference Include="Microsoft.Build" Version="17.9.5" ExcludeAssets="runtime"/>
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8"/>
+        <PackageReference Include="Microsoft.Build" Version="17.10.4" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.10.4" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" ExcludeAssets="runtime" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2"/>
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
-        <PackageReference Include="NuGet.Common" Version="6.9.1"/>
-        <PackageReference Include="NuGet.Configuration" Version="6.9.1"/>
-        <PackageReference Include="NuGet.Packaging" Version="6.9.1"/>
-        <PackageReference Include="NuGet.ProjectModel" Version="6.9.1"/>
-        <PackageReference Include="Serilog" Version="3.1.1"/>
+        <PackageReference Include="NuGet.Packaging" Version="6.10.0" />
+        <PackageReference Include="Serilog" Version="4.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1"/>
         <PackageReference Include="System.IO.Abstractions" Version="21.0.2"/>
         <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
-        <PackageReference Include="YamlDotNet" Version="15.1.2"/>
+        <PackageReference Include="YamlDotNet" Version="15.1.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/dotnet.nugit/dotnet.nugit.csproj
+++ b/src/dotnet.nugit/dotnet.nugit.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <AssemblyName>dotnet-nugit</AssemblyName>
-        <AssemblyVersion>0.3.0</AssemblyVersion>
-        <FileVersion>0.3.0</FileVersion>
+        <AssemblyVersion>0.3.1</AssemblyVersion>
+        <FileVersion>0.3.1</FileVersion>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
@@ -22,7 +22,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/matzefriedrich/dotnet-nugit</RepositoryUrl>
         <Title>dotnet nugit</Title>
-        <Version>0.3.0-alpha1.240606.1</Version>
+        <Version>0.3.1-alpha1.240607.1</Version>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
- Upgrades referenced NuGet packages
- Adds an exception handler to the `ProjectWorkspaceManager` class for MSBuild assembly-related errors
- Extends the `MsBuildToolsLocatorService` class; adds functionality to load `Microsoft.Build.*` assemblies that cannot be shipped along with the app
- Upgrades referenced submodules